### PR TITLE
Kaminari and will_paginate collision

### DIFF
--- a/app/models/feeder/item.rb
+++ b/app/models/feeder/item.rb
@@ -1,5 +1,13 @@
+require 'kaminari/config'
+require 'kaminari/models/page_scope_methods'
+require 'kaminari/models/configuration_methods'
+require 'kaminari/models/active_record_model_extension'
+
 module Feeder
   class Item < ::ActiveRecord::Base
     include Feeder::Concerns::Models::Item
+    include Kaminari::ActiveRecordModelExtension
+
+    singleton_class.send(:alias_method, :kaminari_page, :page)
   end
 end

--- a/lib/feeder.rb
+++ b/lib/feeder.rb
@@ -2,7 +2,6 @@ require "feeder/engine"
 require "feeder/configuration"
 require "feeder/concerns"
 require "feeder/active_record"
-require "kaminari"
 
 module Feeder
 

--- a/lib/feeder/concerns/controllers/items_controller.rb
+++ b/lib/feeder/concerns/controllers/items_controller.rb
@@ -12,7 +12,7 @@ module Feeder
           @items = @items.instance_eval &scope
         end
 
-        @items = @items.page(params[:page] || 1)
+        @items = @items.kaminari_page(params[:page] || 1)
         @items = @items.per(params[:limit] || 25)
 
         respond_with @items

--- a/spec/controllers/feeder/items_controller_spec.rb
+++ b/spec/controllers/feeder/items_controller_spec.rb
@@ -21,6 +21,15 @@ module Feeder
         end
       end
 
+      context 'with a page' do
+        let!(:very_last) { create :feeder_item }
+
+        it 'paginates items' do
+          get :index, page: 2, limit: 1
+          expect(assigns(:items)).to eq [items.last]
+        end
+      end
+
       context 'with stickies' do
         let!(:sticky) { create :feeder_item, :sticky, published_at: 2.day.ago }
         let!(:other)  { create :feeder_item, published_at: 1.day.ago }


### PR DESCRIPTION
I tried to integrate this gem to existing project that historically uses `will_paginate`. It turns out `will_paginate` takes precedence over `kaminari`. See the issue https://github.com/amatsuda/kaminari/issues/162. I took a look at both. Long story short `kaminari` appends class method `page` to every class inherited from AR::B, whereas `will_paginate` pollutes Relation, Association. I think there should be way not to pollute the whole AR but instead use a technique proposed in comments there. Also I think we don't need this line `require kaminari` because it injects the code to AR::B and user's applications may use different gem, instead I suggest inject `kaminari` stuff to `Feeder::Item` manually. WDYT?
