### PR TITLE
Fix an issue with assigning sticky in forms

### DIFF
--- a/lib/feeder/concerns/feedable.rb
+++ b/lib/feeder/concerns/feedable.rb
@@ -22,15 +22,22 @@ module Feeder::Concerns::Feedable
     end
 
     def sticky= value
-      @sticky = value
+      @sticky = booleanize(value)
 
       if feeder_item
-        feeder_item.sticky = value
+        feeder_item.sticky = @sticky
       end
     end
   end
 
   private
+
+  def booleanize value
+    # Piggyback on ActiveRecord's boolean conversion algorithm. We would drop down
+    # a level or two, but the API seems to be considered private; in fact it's
+    # changing in the next release of Ruby on Rails.
+    Feeder::Item.new(sticky: value).sticky
+  end
 
   def _create_feeder_item
     condition = self.class.feedable_options.try(:[], :if)

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20140815105053) do
     t.boolean  "sticky",        default: false, null: false
     t.boolean  "blocked",       default: false, null: false
     t.boolean  "reported",      default: false, null: false
+    t.boolean  "recommended",   default: false, null: false
   end
 
   add_index "feeder_items", ["feedable_id", "feedable_type"], name: "index_feeder_items_on_feedable_id_and_feedable_type"
@@ -36,6 +37,11 @@ ActiveRecord::Schema.define(version: 20140815105053) do
   create_table "messages", force: true do |t|
     t.string   "header"
     t.text     "body"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "users", force: true do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/spec/lib/feeder/concerns/feedable_spec.rb
+++ b/spec/lib/feeder/concerns/feedable_spec.rb
@@ -18,6 +18,12 @@ describe Feeder::Concerns::Feedable do
     expect(subject).to respond_to :sticky=
   end
 
+  it 'converts strings to booleans' do
+    subject.sticky = "0"
+
+    expect(subject.sticky).to eq false
+  end
+
   context 'with a feeder item' do
     before do
       expect(subject).to receive(:feeder_item).and_return(double sticky: true).at_least(1).times


### PR DESCRIPTION
Ruby on Rails uses special values (such as "0") in forms to describe false
because strings are the only type forms can send, but our proxy to assign
sticky in feedables did not consider this and so cast these special values
incorrectly.
