### PR TITLE
Remove need for responders gem

### DIFF
--- a/app/controllers/feeder/application_controller.rb
+++ b/app/controllers/feeder/application_controller.rb
@@ -1,12 +1,4 @@
-require "responders"
-
-class AppResponder < ActionController::Responder
-  include Responders::FlashResponder
-  include Responders::HttpCacheResponder
-end
-
 module Feeder
   class ApplicationController < ::ApplicationController
-    self.responder = AppResponder
   end
 end

--- a/feeder.gemspec
+++ b/feeder.gemspec
@@ -21,7 +21,6 @@ DESC
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency "rails", "~> 4.0"
-  s.add_dependency "responders", "~> 2.0"
   s.add_dependency "kaminari"
   s.add_dependency "acts_as_votable", '~> 0.10.0'
 

--- a/lib/feeder/concerns/controllers/items_controller.rb
+++ b/lib/feeder/concerns/controllers/items_controller.rb
@@ -6,8 +6,6 @@ module Feeder
       include AuthorizationHelper
       include LikeHelper
 
-      respond_to :html, :json
-
       before_action :set_item, only: [:show, :recommend, :unrecommend, :like,
                                       :unlike, :report]
 
@@ -21,11 +19,17 @@ module Feeder
         @items = @items.kaminari_page(params[:page] || 1)
         @items = @items.per(params[:limit] || 25)
 
-        respond_with @items
+        respond_to do |format|
+          format.html
+          format.json
+        end
       end
 
       def show
-        respond_with @item
+        respond_to do |format|
+          format.html
+          format.json
+        end
       end
 
       def recommend
@@ -51,11 +55,21 @@ module Feeder
       end
 
       def like
-        respond_with @item if vote(@item, :vote_by)
+        if vote(@item, :vote_by)
+          respond_to do |format|
+            format.html
+            format.json
+          end
+        end
       end
 
       def unlike
-        respond_with @item if vote(@item, :unvote)
+        if vote(@item, :unvote)
+          respond_to do |format|
+            format.html
+            format.json
+          end
+        end
       end
 
       def report


### PR DESCRIPTION
Yah, that responders gem kinda messed everything up for Rails versions before 4.2 (at least responders ~> 2.0). So let's just not use it, eh?
